### PR TITLE
Fix method signature remapping in Inject annotations

### DIFF
--- a/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
@@ -201,14 +201,15 @@ public class MixinRemapperVisitor extends ASTVisitor {
 
                 // Find target method(s?)
                 // todo: implement selectors
-                final String[] method = new String[inject.getMethod().length];
-                for (int j = 0; j < inject.getMethod().length; j++) {
-                    final String targetMethod = inject.getMethod()[j];
-                    String deobf = targetMethod;
+                final String[] method = new String[inject.getMethodSignatures().length];
+                for (int j = 0; j < inject.getMethodSignatures().length; j++) {
+                    final MethodSignature targetMethod = inject.getMethodSignatures()[j];
+                    String deobf = targetMethod.getName() + targetMethod.getDescriptor().toString();
 
                     for (final MethodMapping mapping : target.getMethodMappings()) {
-                        if (Objects.equals(targetMethod, mapping.getObfuscatedName())) {
-                            deobf = mapping.getDeobfuscatedName();
+                        if (Objects.equals(targetMethod.getName(), mapping.getObfuscatedName())) {
+                            MethodSignature deobfuscatedSignature = mapping.getDeobfuscatedSignature();
+                            deobf = deobfuscatedSignature.getName() + deobfuscatedSignature.getDescriptor().toString();
                             break;
                         }
                     }

--- a/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
@@ -27,6 +27,7 @@ import org.cadixdev.mercury.analysis.MercuryInheritanceProvider;
 import org.cadixdev.mercury.mixin.annotation.AccessorData;
 import org.cadixdev.mercury.mixin.annotation.AccessorName;
 import org.cadixdev.mercury.mixin.annotation.InjectData;
+import org.cadixdev.mercury.mixin.annotation.MethodTarget;
 import org.cadixdev.mercury.mixin.annotation.MixinClass;
 import org.cadixdev.mercury.mixin.annotation.ShadowData;
 import org.cadixdev.mercury.util.BombeBindings;
@@ -201,13 +202,19 @@ public class MixinRemapperVisitor extends ASTVisitor {
 
                 // Find target method(s?)
                 // todo: implement selectors
-                final String[] method = new String[inject.getMethodSignatures().length];
-                for (int j = 0; j < inject.getMethodSignatures().length; j++) {
-                    final MethodSignature targetMethod = inject.getMethodSignatures()[j];
-                    String deobf = targetMethod.getName() + targetMethod.getDescriptor().toString();
+                final String[] method = new String[inject.getMethodTargets().length];
+                for (int j = 0; j < inject.getMethodTargets().length; j++) {
+                    final MethodTarget targetMethod = inject.getMethodTargets()[j];
+                    String targetMethodName = targetMethod.getMethodName();
+                    String deobf = targetMethodName + targetMethod.getMethodDescriptor()
+                            .map(MethodDescriptor::toString)
+                            .orElse("");
 
                     for (final MethodMapping mapping : target.getMethodMappings()) {
-                        if (Objects.equals(targetMethod.getName(), mapping.getObfuscatedName())) {
+                        if (Objects.equals(targetMethodName, mapping.getObfuscatedName()) &&
+                                targetMethod.getMethodDescriptor()
+                                        .map(d -> d.equals(mapping.getDescriptor()))
+                                        .orElse(true)) {
                             MethodSignature deobfuscatedSignature = mapping.getDeobfuscatedSignature();
                             deobf = deobfuscatedSignature.getName() + deobfuscatedSignature.getDescriptor().toString();
                             break;

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/InjectData.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/InjectData.java
@@ -6,7 +6,6 @@
 
 package org.cadixdev.mercury.mixin.annotation;
 
-import org.cadixdev.bombe.type.signature.MethodSignature;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
 
@@ -22,30 +21,30 @@ public class InjectData {
 
     // @Inject(method={"example"}, at=@At(...))
     public static InjectData from(final IAnnotationBinding binding) {
-        MethodSignature[] methodSignatures = {};
+        MethodTarget[] methodTargets = {};
 
         for (final IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
             if (Objects.equals("method", pair.getName())) {
                 final Object[] raw = (Object[]) pair.getValue();
 
-                methodSignatures = new MethodSignature[raw.length];
+                methodTargets = new MethodTarget[raw.length];
                 for (int i = 0; i < raw.length; i++) {
-                    methodSignatures[i] = MethodSignature.of((String) raw[i]);
+                    methodTargets[i] = MethodTarget.of((String) raw[i]);
                 }
             }
         }
 
-        return new InjectData(methodSignatures);
+        return new InjectData(methodTargets);
     }
 
-    private final MethodSignature[] methodSignatures;
+    private final MethodTarget[] methodTargets;
 
-    public InjectData(final MethodSignature[] methodSignatures) {
-        this.methodSignatures = methodSignatures;
+    public InjectData(final MethodTarget[] methodTargets) {
+        this.methodTargets = methodTargets;
     }
 
-    public MethodSignature[] getMethodSignatures() {
-        return this.methodSignatures;
+    public MethodTarget[] getMethodTargets() {
+        return this.methodTargets;
     }
 
 }

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/InjectData.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/InjectData.java
@@ -6,6 +6,7 @@
 
 package org.cadixdev.mercury.mixin.annotation;
 
+import org.cadixdev.bombe.type.signature.MethodSignature;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
 
@@ -21,30 +22,30 @@ public class InjectData {
 
     // @Inject(method={"example"}, at=@At(...))
     public static InjectData from(final IAnnotationBinding binding) {
-        String[] method = {};
+        MethodSignature[] methodSignatures = {};
 
         for (final IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
             if (Objects.equals("method", pair.getName())) {
                 final Object[] raw = (Object[]) pair.getValue();
 
-                method = new String[raw.length];
+                methodSignatures = new MethodSignature[raw.length];
                 for (int i = 0; i < raw.length; i++) {
-                    method[i] = (String) raw[i];
+                    methodSignatures[i] = MethodSignature.of((String) raw[i]);
                 }
             }
         }
 
-        return new InjectData(method);
+        return new InjectData(methodSignatures);
     }
 
-    private final String[] method;
+    private final MethodSignature[] methodSignatures;
 
-    public InjectData(final String[] method) {
-        this.method = method;
+    public InjectData(final MethodSignature[] methodSignatures) {
+        this.methodSignatures = methodSignatures;
     }
 
-    public String[] getMethod() {
-        return this.method;
+    public MethodSignature[] getMethodSignatures() {
+        return this.methodSignatures;
     }
 
 }

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/MethodTarget.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/MethodTarget.java
@@ -1,0 +1,50 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.cadixdev.mercury.mixin.annotation;
+
+import org.cadixdev.bombe.type.MethodDescriptor;
+import org.cadixdev.bombe.type.signature.MethodSignature;
+
+import java.util.Optional;
+
+/**
+ * Method target can either be a method name or a method signature
+ *
+ * @author Jadon Fowler
+ */
+public class MethodTarget {
+
+    private final String methodName;
+    private final MethodDescriptor methodDescriptor;
+
+    public MethodTarget(String methodName) {
+        this.methodName = methodName;
+        this.methodDescriptor = null;
+    }
+
+    public MethodTarget(String methodName, MethodDescriptor methodDescriptor) {
+        this.methodName = methodName;
+        this.methodDescriptor = methodDescriptor;
+    }
+
+    public static MethodTarget of(String target) {
+        int index = target.indexOf('(');
+        if (index >= 0) {
+            return new MethodTarget(target.substring(0, index), MethodDescriptor.of(target.substring(index)));
+        }
+        return new MethodTarget(target);
+    }
+
+    public String getMethodName() {
+        return this.methodName;
+    }
+
+    public Optional<MethodDescriptor> getMethodDescriptor() {
+        return Optional.ofNullable(methodDescriptor);
+    }
+
+}

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/MixinClass.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/MixinClass.java
@@ -44,7 +44,11 @@ public class MixinClass {
                         targetsTemp = (Object[]) pair.getValue();
                     }
                     if (Objects.equals("targets", pair.getName())) {
-                        privateTargets = (String[]) pair.getValue();
+                        Object[] privateTargetObjects = (Object[]) pair.getValue();
+                        privateTargets = new String[privateTargetObjects.length];
+                        for (int i = 0; i < privateTargetObjects.length; i++) {
+                            privateTargets[i] = (String) privateTargetObjects[i];
+                        }
                     }
                 }
             }

--- a/src/main/java/org/cadixdev/mercury/mixin/util/MixinConstants.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/util/MixinConstants.java
@@ -18,6 +18,7 @@ public final class MixinConstants {
     public static final String FINAL_CLASS = MIXIN_PACKAGE + ".Final";
     public static final String MUTABLE_CLASS = MIXIN_PACKAGE + ".Mutable";
     public static final String INJECT_CLASS = INJECTOR_PACKAGE + ".Inject";
+    public static final String AT_CLASS = INJECT_CLASS + ".At";
     public static final String ACCESSOR_CLASS = GEN_PACKAGE + ".Accessor";
 
     private MixinConstants() {

--- a/src/main/java/org/cadixdev/mercury/mixin/util/MixinConstants.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/util/MixinConstants.java
@@ -18,7 +18,7 @@ public final class MixinConstants {
     public static final String FINAL_CLASS = MIXIN_PACKAGE + ".Final";
     public static final String MUTABLE_CLASS = MIXIN_PACKAGE + ".Mutable";
     public static final String INJECT_CLASS = INJECTOR_PACKAGE + ".Inject";
-    public static final String AT_CLASS = INJECT_CLASS + ".At";
+    public static final String AT_CLASS = INJECTOR_PACKAGE + ".At";
     public static final String ACCESSOR_CLASS = GEN_PACKAGE + ".Accessor";
 
     private MixinConstants() {


### PR DESCRIPTION
Previously it was assumed that the method in Inject annotation
was the _method name_ instead of the _method signature_. They
are now remapped properly.