### PR TITLE
Remap At Annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# MercuryMixin
+
+MercuryMixin is an addon library for [Mercury](https://github.com/CadixDev/Mercury)
+that remaps [Mixins](https://github.com/SpongePowered/Mixin).
+
+## Usage
+
+Add the `MixinRemapper` before the `MercuryRemapper`:
+
+```java
+Mercury mercury = new Mercury();
+mercury.getProcessors().add(MixinRemapper.create(mappings));
+mercury.getProcessors().add(MercuryRemapper.create(mappings));
+```

--- a/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
@@ -216,7 +216,11 @@ public class MixinRemapperVisitor extends ASTVisitor {
                                         .map(d -> d.equals(mapping.getDescriptor()))
                                         .orElse(true)) {
                             MethodSignature deobfuscatedSignature = mapping.getDeobfuscatedSignature();
-                            deobf = deobfuscatedSignature.getName() + deobfuscatedSignature.getDescriptor().toString();
+                            if (targetMethod.getMethodDescriptor().isPresent()) {
+                                deobf = deobfuscatedSignature.getName() + deobfuscatedSignature.getDescriptor().toString();
+                            } else {
+                                deobf = deobfuscatedSignature.getName();
+                            }
                             break;
                         }
                     }

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/AtData.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/AtData.java
@@ -25,8 +25,13 @@ public class AtData {
             } else if (Objects.equals("target", pair.getName())) {
                 String combined = (String) pair.getValue();
                 int semiIndex = combined.indexOf(';');
-                className = combined.substring(1, semiIndex);
-                target = MethodTarget.of(combined.substring(semiIndex + 1));
+                if (semiIndex >= 0) {
+                    className = combined.substring(1, semiIndex);
+                    target = MethodTarget.of(combined.substring(semiIndex + 1));
+                } else {
+                    // it's just the class name, probably a NEW
+                    className = combined;
+                }
             }
         }
 

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/AtData.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/AtData.java
@@ -1,0 +1,67 @@
+package org.cadixdev.mercury.mixin.annotation;
+
+import org.eclipse.jdt.core.dom.IAnnotationBinding;
+import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A container for data held in the {@code @At} annotation.
+ *
+ * @author Jadon Fowler
+ */
+public class AtData {
+
+    // @At(value = "", target = "")
+    public static AtData from(final IAnnotationBinding binding) {
+        String injectionPoint = null;
+        String className = null;
+        MethodTarget target = null;
+
+        for (final IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
+            if (Objects.equals("value", pair.getName())) {
+                injectionPoint = (String) pair.getValue();
+            } else if (Objects.equals("target", pair.getName())) {
+                String combined = (String) pair.getValue();
+                int semiIndex = combined.indexOf(';');
+                className = combined.substring(1, semiIndex);
+                target = MethodTarget.of(combined.substring(semiIndex + 1));
+            }
+        }
+
+        return new AtData(injectionPoint, className, target);
+    }
+
+    private final String injectionPoint;
+    private final String className;
+    private final MethodTarget target;
+
+    public AtData(final String injectionPoint, final String className, final MethodTarget target) {
+        this.injectionPoint = injectionPoint;
+        this.className = className;
+        this.target = target;
+    }
+
+    public String getInjectionPoint() {
+        return injectionPoint;
+    }
+
+    public Optional<String> getClassName() {
+        return Optional.ofNullable(className);
+    }
+
+    public Optional<MethodTarget> getTarget() {
+        return Optional.ofNullable(target);
+    }
+
+    @Override
+    public String toString() {
+        return "AtData{" +
+                "injectionPoint='" + injectionPoint + '\'' +
+                ", className='" + className + '\'' +
+                ", target=" + target +
+                '}';
+    }
+
+}

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/InjectData.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/InjectData.java
@@ -9,6 +9,7 @@ package org.cadixdev.mercury.mixin.annotation;
 import org.eclipse.jdt.core.dom.IAnnotationBinding;
 import org.eclipse.jdt.core.dom.IMemberValuePairBinding;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -22,6 +23,7 @@ public class InjectData {
     // @Inject(method={"example"}, at=@At(...))
     public static InjectData from(final IAnnotationBinding binding) {
         MethodTarget[] methodTargets = {};
+        AtData[] atData = {};
 
         for (final IMemberValuePairBinding pair : binding.getDeclaredMemberValuePairs()) {
             if (Objects.equals("method", pair.getName())) {
@@ -31,20 +33,41 @@ public class InjectData {
                 for (int i = 0; i < raw.length; i++) {
                     methodTargets[i] = MethodTarget.of((String) raw[i]);
                 }
+            } else if (Objects.equals("at", pair.getName())) {
+                final Object[] raw = (Object[]) pair.getValue();
+
+                atData = new AtData[raw.length];
+                for (int i = 0; i < raw.length; i++) {
+                    atData[i] = AtData.from((IAnnotationBinding) raw[i]);
+                }
             }
         }
 
-        return new InjectData(methodTargets);
+        return new InjectData(methodTargets, atData);
     }
 
     private final MethodTarget[] methodTargets;
+    private final AtData[] atData;
 
-    public InjectData(final MethodTarget[] methodTargets) {
+    public InjectData(final MethodTarget[] methodTargets, final AtData[] atData) {
         this.methodTargets = methodTargets;
+        this.atData = atData;
     }
 
     public MethodTarget[] getMethodTargets() {
         return this.methodTargets;
+    }
+
+    public AtData[] getAtData() {
+        return atData;
+    }
+
+    @Override
+    public String toString() {
+        return "InjectData{" +
+                "methodTargets=" + Arrays.toString(methodTargets) +
+                ", atData=" + Arrays.toString(atData) +
+                '}';
     }
 
 }

--- a/src/main/java/org/cadixdev/mercury/mixin/annotation/MethodTarget.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/annotation/MethodTarget.java
@@ -7,7 +7,6 @@
 package org.cadixdev.mercury.mixin.annotation;
 
 import org.cadixdev.bombe.type.MethodDescriptor;
-import org.cadixdev.bombe.type.signature.MethodSignature;
 
 import java.util.Optional;
 
@@ -45,6 +44,14 @@ public class MethodTarget {
 
     public Optional<MethodDescriptor> getMethodDescriptor() {
         return Optional.ofNullable(methodDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return "MethodTarget{" +
+                "methodName='" + methodName + '\'' +
+                ", methodDescriptor=" + methodDescriptor +
+                '}';
     }
 
 }

--- a/src/test/resources/common/src/hj.java
+++ b/src/test/resources/common/src/hj.java
@@ -26,6 +26,8 @@ public class hj {
     }
 
     public void hhj() {
+        int age = julp();
+        gyhu();
     }
 
 }

--- a/src/test/resources/mixin/a/TestTargetMixin.java
+++ b/src/test/resources/mixin/a/TestTargetMixin.java
@@ -43,4 +43,9 @@ public abstract class TestTargetMixin {
         System.out.println("Hello, world!");
     }
 
+    @Inject(method = {"hhj()V", "jjjj"}, at = @At("HEAD"))
+    public void onStart2(final CallbackInfo callbackInfo) {
+        System.out.println("Hello, world!");
+    }
+
 }

--- a/src/test/resources/mixin/a/TestTargetMixin.java
+++ b/src/test/resources/mixin/a/TestTargetMixin.java
@@ -48,4 +48,18 @@ public abstract class TestTargetMixin {
         System.out.println("Hello, world!");
     }
 
+    @Inject(method = "hhj", at = @At(value = "INVOKE", target = "Lhj;gyhu()V"))
+    public void inject(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from injection!");
+    }
+
+    @Inject(method = "hhj", at = {
+            @At("HEAD"),
+            @At(value = "INVOKE", target = "Lhj;julp()I"),
+            @At(value = "INVOKE_ASSIGN", target = "Lhj;gyhu()V")
+    })
+    public void injectMultiple(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from injection!");
+    }
+
 }

--- a/src/test/resources/mixin/a/TestTargetMixin.java
+++ b/src/test/resources/mixin/a/TestTargetMixin.java
@@ -62,4 +62,9 @@ public abstract class TestTargetMixin {
         System.out.println("Hello from injection!");
     }
 
+    @Inject(method = "hhj", at = @At(value = "NEW", target = "hj"))
+    public void injectNew(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from new injection!");
+    }
+
 }

--- a/src/test/resources/mixin/b/TestTargetMixin.java
+++ b/src/test/resources/mixin/b/TestTargetMixin.java
@@ -38,8 +38,13 @@ public abstract class TestTargetMixin {
         System.out.println("Hello, world!");
     }
 
-    @Inject(method = {"start()V", "jjjj"}, at = @At("HEAD"))
+    @Inject(method = {"start", "jjjj"}, at = @At("HEAD"))
     public void onStart(final CallbackInfo callbackInfo) {
+        System.out.println("Hello, world!");
+    }
+
+    @Inject(method = {"start()V", "jjjj"}, at = @At("HEAD"))
+    public void onStart2(final CallbackInfo callbackInfo) {
         System.out.println("Hello, world!");
     }
 

--- a/src/test/resources/mixin/b/TestTargetMixin.java
+++ b/src/test/resources/mixin/b/TestTargetMixin.java
@@ -48,4 +48,18 @@ public abstract class TestTargetMixin {
         System.out.println("Hello, world!");
     }
 
+    @Inject(method = "start", at = @At(value = "INVOKE", target = "LTestTarget;run()V"))
+    public void inject(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from injection!");
+    }
+
+    @Inject(method = "start", at = {
+            @At("HEAD"),
+            @At(value = "INVOKE", target = "LTestTarget;getAge()I"),
+            @At(value = "INVOKE_ASSIGN", target = "LTestTarget;run()V")
+    })
+    public void injectMultiple(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from injection!");
+    }
+
 }

--- a/src/test/resources/mixin/b/TestTargetMixin.java
+++ b/src/test/resources/mixin/b/TestTargetMixin.java
@@ -62,4 +62,9 @@ public abstract class TestTargetMixin {
         System.out.println("Hello from injection!");
     }
 
+    @Inject(method = "start", at = @At(value = "NEW", target = "TestTarget"))
+    public void injectNew(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from new injection!");
+    }
+
 }


### PR DESCRIPTION
This remaps `@At`s in `@Inject` and supports single class and class + method remapping in the `target`.

I also added a README and fixed the issue of `hhj` mapping to `start()V` instead of `start`.