### PR TITLE
Remap classes in At annotations when method/field mappings don't exist

### DIFF
--- a/src/test/resources/mixin/a/TestTargetMixin.java
+++ b/src/test/resources/mixin/a/TestTargetMixin.java
@@ -57,6 +57,11 @@ public abstract class TestTargetMixin {
         System.out.println("Hello from injection!");
     }
 
+    @Inject(method = "hhj", at = @At(value = "INVOKE", target = "Lhj;unknownMethod()V"))
+    public void injectIntoUnknownMethod(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from injection part 2!");
+    }
+
     @Inject(method = "hhj", at = {
             @At("HEAD"),
             @At(value = "INVOKE", target = "Lhj;julp()I"),

--- a/src/test/resources/mixin/b/TestTargetMixin.java
+++ b/src/test/resources/mixin/b/TestTargetMixin.java
@@ -57,6 +57,11 @@ public abstract class TestTargetMixin {
         System.out.println("Hello from injection!");
     }
 
+    @Inject(method = "start", at = @At(value = "INVOKE", target = "LTestTarget;unknownMethod()V"))
+    public void injectIntoUnknownMethod(final CallbackInfo callbackInfo) {
+        System.out.println("Hello from injection part 2!");
+    }
+
     @Inject(method = "start", at = {
             @At("HEAD"),
             @At(value = "INVOKE", target = "LTestTarget;getAge()I"),


### PR DESCRIPTION
When remapping a Class + X target, if the X doesn't have a mapping then
the class wouldn't be remapped.