### PR TITLE
Correct handling of mixin targets that are neither string literals or arrays

### DIFF
--- a/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
+++ b/src/main/java/org/cadixdev/mercury/mixin/MixinRemapperVisitor.java
@@ -328,11 +328,12 @@ public class MixinRemapperVisitor extends ASTVisitor {
                     final MemberValuePair pair = (MemberValuePair) raw;
 
                     // Remap the method pair
+                    // TODO: handle the case where we point towards a string constant?
                     if (Objects.equals("method", pair.getName().getIdentifier())) {
                         if (pair.getValue() instanceof StringLiteral || pair.getValue() instanceof InfixExpression) {
                             replaceExpression(ast, this.context, pair.getValue(), injectTargets[0]);
                         }
-                        else {
+                        else if (pair.getValue() instanceof ArrayInitializer) {
                             final ArrayInitializer array = (ArrayInitializer) pair.getValue();
                             for (int j = 0; j < array.expressions().size(); j++) {
                                 final StringLiteral original = (StringLiteral) array.expressions().get(j);


### PR DESCRIPTION
This came up when remapping Sponge, at https://github.com/SpongePowered/Sponge/blob/a5629f7ee7c1b85b3c3ad173d80f5adb56e3c8fd/src/mixins/java/org/spongepowered/common/mixin/core/commands/CommandSourceStackMixin.java#L89

The target selector was being improperly casted to an array literal, when it was a reference to a constant field.